### PR TITLE
Implement `MrHorse.parallel`, switch Async to Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ var routes = [
 ```
 
 ##### Running policies in parallel
-If you'd like to run policies in parallel, you can specify a list of loaded policies in parentheses or explicitly as arguments to `MrHorse.parallel`.
+If you'd like to run policies in parallel, you can specify a list of loaded policies as an array or as individual arguments to `MrHorse.parallel`.
 When policies are run in parallel, expect all policies to complete.  If any of the policies specify an error or `Forbidden 403` message, by default the first listed policy with such an error will be given precedence.
 
 ```javascript
@@ -292,7 +292,7 @@ var routes = [
 ];
 ```
 
-`MrHorse.parallel` optionally accepts a custom error handler as its final argument.  This may be used to aggregate errors from multiple policies into a single custom error or message.  The function signature of this function is `next(ranPolicies, results, next)`,
+`MrHorse.parallel` optionally accepts a custom error handler as its final argument.  This may be used to aggregate errors from multiple policies into a single custom error or message.  The function signature of this function is `next(ranPolicies, results, next)`.
 
  - `ranPolicies` is an array of the names of the policies that were run, with original listed order maintained.
  - `results` is an object whose keys are the names of the listed policies that ran, and whose values are objects of the format,

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ var hasRole = function(roleName) {
     hasSpecificRole.applyPoint = 'onPreHandler';
     
     return hasSpecificRole;
-}
+};
 
 var routes = [
    {

--- a/lib/index.js
+++ b/lib/index.js
@@ -134,7 +134,7 @@ _applyPoints.forEach(function (applyPoint) {
                 }
 
             } else if (typeof routePolicy === 'function') {
-                
+
                 // If an aggregate apply point wasn't already determined
                 // but an aggregate apply point seems like it will be used, determine it from `policy.runs`.
                 // `policy.runs` is an array of loaded policies reported by an aggregate policy

--- a/lib/index.js
+++ b/lib/index.js
@@ -235,6 +235,9 @@ var reset = function reset () {
         setHandlers: {}
     };
 
+    /* clear memoize cache */
+    determineAggregateApplyPoint.cache.__data__ = {};
+
     /* adding arrays to hold the policies */
     _applyPoints.forEach(function (applyPoint) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ var runPolicies = function (policiesToRun, request, reply) {
         });
     };
 
-    // Use eachSeries to get quick fails and ordering
+    // Run the policies in order
     Items.serial(policiesToRun, checkPolicy, function (err) {
 
         if (!reply._replied) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
-var Async = require('async');
+var Items = require('items');
 var Boom = require('boom');
 var Fs = require('fs');
 var Hoek = require('hoek');
@@ -19,8 +19,35 @@ var hasValidApplyPoint = function (policy) {
     return !policy.applyPoint || _applyPoints.indexOf(policy.applyPoint) !== -1;
 };
 
+var determineAggregateApplyPoint = function (policyNames) {
+
+    Hoek.assert(Array.isArray(policyNames), 'Requires array of policy names.');
+    Hoek.assert(policyNames.length > 0, 'Requires non-empty array of policy names.');
+    Hoek.assert(_.intersection(data.names, policyNames).length === policyNames.length, 'Requires loaded policy names.');
+
+    var firstPolicy = policyNames[0];
+
+    var applyPoint;
+    for (var i = 0; i < _applyPoints.length; ++i) {
+
+        // Check if the first policy appears to have this apply point.
+        if (!applyPoint &&
+            Object.keys(data[_applyPoints[i]]).indexOf(firstPolicy) !== -1) {
+
+            applyPoint = _applyPoints[i];
+        }
+    }
+
+    Hoek.assert(applyPoint, 'Policies must be in a valid applyPoint.');
+    Hoek.assert(_.intersection(Object.keys(data[applyPoint]), policyNames).length === policyNames.length,
+                'Aggregate policies must be from same applyPoint.');
+
+    return applyPoint;
+};
+
 var data = {
     names: [],
+    rawPolicies: {},
     setHandlers: {}
 };
 
@@ -48,7 +75,7 @@ var runPolicies = function (policiesToRun, request, reply) {
     };
 
     // Use eachSeries to get quick fails and ordering
-    Async.eachSeries(policiesToRun, checkPolicy, function (err) {
+    Items.serial(policiesToRun, checkPolicy, function (err) {
 
         if (!reply._replied) {
             if (err) {
@@ -94,12 +121,18 @@ _applyPoints.forEach(function (applyPoint) {
 
             } else if (typeof routePolicy === 'function') {
 
+                var aggregateApplyPoint;
+                if (routePolicy.runs && !routePolicy.applyPoint) {
+
+                    aggregateApplyPoint = determineAggregateApplyPoint(routePolicy.runs);
+                }
+
                 if (!hasValidApplyPoint(routePolicy)) {
                     repliedWithError = true;
                     return reply(Boom.badImplementation('Trying to use incorrect applyPoint for the dynamic policy: ' + routePolicy.applyPoint));
                 }
 
-                var effectiveApplyPoint = routePolicy.applyPoint || request.server.plugins.mrhorse.defaultApplyPoint;
+                var effectiveApplyPoint = routePolicy.applyPoint || aggregateApplyPoint || request.server.plugins.mrhorse.defaultApplyPoint;
 
                 if (effectiveApplyPoint === applyPoint) {
                     tmpList.push(routePolicy);
@@ -145,8 +178,6 @@ var loadPolicies = function (server, options, next) {
                 return addPolicyNext(new Error('Trying to add a duplicate policy: ' + match[1]));
             }
 
-            data.names.push(match[1]);
-
             // Add this policy function to the data object
             var policy = require(Path.join(options.policyDirectory, filename));
 
@@ -160,8 +191,10 @@ var loadPolicies = function (server, options, next) {
             if (policy.applyPoint === undefined || policy.applyPoint) {
                 var applyPoint = policy.applyPoint || options.defaultApplyPoint;
 
-                server.log(['info'], 'Adding a new PRE policy called ' + match[1]);
+                server.log(['info'], 'Adding a new policy called ' + match[1]);
                 data[applyPoint][match[1]] = policy;
+                data.rawPolicies[match[1]] = policy;
+                data.names.push(match[1]);
 
                 // connect the handler if this is the first pre policy
                 if (!data.setHandlers[applyPoint]) {
@@ -174,7 +207,7 @@ var loadPolicies = function (server, options, next) {
         addPolicyNext();
     };
 
-    Async.eachSeries(policyFiles, addPolicy, function (err) {
+    Items.serial(policyFiles, addPolicy, function (err) {
 
         next(err);
     });
@@ -184,6 +217,7 @@ var reset = function reset () {
 
     data = {
         names: [],
+        rawPolicies: {},
         setHandlers: {}
     };
 
@@ -218,4 +252,87 @@ exports.register = function register (server, options, next) {
 
 exports.register.attributes = {
     pkg: require('../package.json')
+};
+
+/* Policy aggregation tools */
+exports.parallel = function (/*policy1, policy2, [cb]*/) {
+
+    Hoek.assert(arguments.length, 'Requires at least one argument.');
+
+    var args = Array.prototype.slice.call(arguments);
+
+    // This error aggregator is used by default, giving priority to error responses
+    // by the policies' listed order.
+    var defaultErrorHandler = function (ranPolicies, results, next) {
+
+        var result;
+        for (var i = 0; i < ranPolicies.length; ++i) {
+
+            result = results[ranPolicies[i]];
+
+            if (result.err || !result.canContinue) {
+
+                next(result.err, result.canContinue, result.message);
+                break;
+            }
+
+        }
+
+        next(null, true);
+    };
+
+    // Determine the error handler and policies we're using
+    var errorHandler;
+    var policyNames;
+    if (typeof args[args.length - 1] === 'function') {
+
+        errorHandler = args[args.length - 1];
+        policyNames = args.slice(0, -1);
+    } else {
+
+        errorHandler = defaultErrorHandler;
+        policyNames = args;
+    }
+
+    Hoek.assert(_.uniq(policyNames).length === policyNames.length, 'Listed policies must be unique.');
+
+    // Wraps policy for use in Items.parallel.execute, never errors.
+    var wrapPolicy = function (policy, request, reply) {
+
+        return function (next) {
+
+            policy(request, reply, function (err, canContinue, message) {
+
+                next(null, {
+                    err: err,
+                    canContinue: canContinue,
+                    message: message
+                });
+            });
+        };
+    };
+
+    // Aggregate policy
+    var aggregatePolicy = function (request, reply, next) {
+
+        var policies = _(data.rawPolicies)
+                        .pick(policyNames)
+                        .mapValues(function (policy) {
+
+                            return wrapPolicy(policy, request, reply);
+                        }).value();
+
+        Items.parallel.execute(policies, function (err, results) {
+
+            Hoek.assert(!err, 'There should never be an error here because of wrapPolicy.');
+
+            errorHandler(policyNames, results, next);
+        });
+    };
+
+    // Report to MrHorse handler which policies are going to be run
+    aggregatePolicy.runs = policyNames;
+
+    // Here ya go!
+    return aggregatePolicy;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -134,7 +134,12 @@ _applyPoints.forEach(function (applyPoint) {
                 }
 
             } else if (typeof routePolicy === 'function') {
-
+                
+                // If an aggregate apply point wasn't already determined
+                // but an aggregate apply point seems like it will be used, determine it from `policy.runs`.
+                // `policy.runs` is an array of loaded policies reported by an aggregate policy
+                // such as MrHorse.parallel, specifically for determining
+                // its apply point ad hoc, notably here in the extension handler.
                 if (!aggregateApplyPoint && routePolicy.runs && !routePolicy.applyPoint) {
 
                     aggregateApplyPoint = determineAggregateApplyPoint(routePolicy.runs);

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,8 @@ var hasValidApplyPoint = function (policy) {
     return !policy.applyPoint || _applyPoints.indexOf(policy.applyPoint) !== -1;
 };
 
-var determineAggregateApplyPoint = function (policyNames) {
+// Memoizes by converting ['policy1', ..., 'policyN'] to 'policy1,...,policyN' as key
+var determineAggregateApplyPoint = _.memoize(function (policyNames) {
 
     Hoek.assert(Array.isArray(policyNames), 'Requires array of policy names.');
     Hoek.assert(policyNames.length > 0, 'Requires non-empty array of policy names.');
@@ -43,7 +44,7 @@ var determineAggregateApplyPoint = function (policyNames) {
                 'Aggregate policies must be from same applyPoint.');
 
     return applyPoint;
-};
+});
 
 var data = {
     names: [],
@@ -107,6 +108,19 @@ _applyPoints.forEach(function (applyPoint) {
                 return;
             }
 
+            // Transform array to parallel, determine apply point in advance
+            var aggregateApplyPoint;
+            if (Array.isArray(routePolicy)) {
+
+                aggregateApplyPoint = determineAggregateApplyPoint(routePolicy);
+
+                if (aggregateApplyPoint === applyPoint) {
+                    routePolicy = exports.parallel.apply(this, routePolicy);
+                } else {
+                    routePolicy = null;
+                }
+            }
+
             if (typeof routePolicy === 'string') {
 
                 // Look for missing policies.  Probably due to misspelling.
@@ -121,8 +135,7 @@ _applyPoints.forEach(function (applyPoint) {
 
             } else if (typeof routePolicy === 'function') {
 
-                var aggregateApplyPoint;
-                if (routePolicy.runs && !routePolicy.applyPoint) {
+                if (!aggregateApplyPoint && routePolicy.runs && !routePolicy.applyPoint) {
 
                     aggregateApplyPoint = determineAggregateApplyPoint(routePolicy.runs);
                 }
@@ -137,7 +150,8 @@ _applyPoints.forEach(function (applyPoint) {
                 if (effectiveApplyPoint === applyPoint) {
                     tmpList.push(routePolicy);
                 }
-            } else {
+
+            } else if (routePolicy !== null) {
 
                 repliedWithError = true;
                 return reply(Boom.badImplementation('Policy not specified by name or by function.'));

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,7 @@
 {
   "name": "mrhorse",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "dependencies": {
-    "async": {
-      "version": "1.3.0",
-      "from": "async@1.3.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.3.0.tgz"
-    },
     "boom": {
       "version": "2.8.0",
       "from": "boom@2.8.0",
@@ -16,6 +11,11 @@
       "version": "2.14.0",
       "from": "hoek@2.14.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
+    },
+    "items": {
+      "version": "1.1.0",
+      "from": "items@1.1.0",
+      "resolved": "https://registry.npmjs.org/items/-/items-1.1.0.tgz"
     },
     "lodash": {
       "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/mark-bradshaw/mrhorse",
   "dependencies": {
-    "async": "^1.3.0",
+    "items": "^1.1.0",
     "boom": "^2.8.0",
     "hoek": "^2.14.0",
     "lodash": "^3.10.0"

--- a/test/index.js
+++ b/test/index.js
@@ -314,7 +314,7 @@ lab.experiment('Normal setup', function (done) {
             },
             config : {
                 plugins: {
-                    policies: [require('./policies/passes')]
+                    policies: [ require('./policies/passes') ]
                 }
             }
         });
@@ -328,7 +328,7 @@ lab.experiment('Normal setup', function (done) {
             },
             config : {
                 plugins: {
-                    policies: [require('./fixtures/incorrectApplyPoint')]
+                    policies: [ require('./fixtures/incorrectApplyPoint') ]
                 }
             }
         });
@@ -344,7 +344,7 @@ lab.experiment('Normal setup', function (done) {
             },
             config : {
                 plugins: {
-                    policies: [require('./policies/postHandler')]
+                    policies: [ require('./policies/postHandler') ]
                 }
             }
         });
@@ -360,7 +360,7 @@ lab.experiment('Normal setup', function (done) {
             },
             config : {
                 plugins: {
-                    policies: [{object: 'invalidPlainObject'}]
+                    policies: [ {object: 'invalidPlainObject'} ]
                 }
             }
         });
@@ -376,7 +376,7 @@ lab.experiment('Normal setup', function (done) {
             },
             config : {
                 plugins: {
-                    policies: [MrHorse.parallel('postHandler', 'postHandlerAnother')]
+                    policies: [ MrHorse.parallel('postHandler', 'postHandlerAnother') ]
                 }
             }
         });
@@ -392,7 +392,7 @@ lab.experiment('Normal setup', function (done) {
             },
             config : {
                 plugins: {
-                    policies: [MrHorse.parallel('passes', 'fails')]
+                    policies: [ MrHorse.parallel('passes', 'fails') ]
                 }
             }
         });
@@ -408,7 +408,7 @@ lab.experiment('Normal setup', function (done) {
             },
             config : {
                 plugins: {
-                    policies: [MrHorse.parallel('customError', 'passes')]
+                    policies: [ MrHorse.parallel('customError', 'passes') ]
                 }
             }
         });
@@ -424,7 +424,7 @@ lab.experiment('Normal setup', function (done) {
             },
             config : {
                 plugins: {
-                    policies: [MrHorse.parallel('passes', 'timedCustomMessageLate', 'timedCustomMessageEarly')]
+                    policies: [ MrHorse.parallel('passes', 'timedCustomMessageLate', 'timedCustomMessageEarly') ]
                 }
             }
         });
@@ -452,6 +452,24 @@ lab.experiment('Normal setup', function (done) {
             }
         });
 
+        server.route({
+            method : 'GET',
+            path   : '/parallel-as-array',
+            handler: function (request, reply) {
+
+                reply({
+                    handler: 'handler'
+                });
+            },
+            config : {
+                plugins: {
+                    policies: [
+                        ['postHandler', 'postHandlerAnother']
+                    ]
+                }
+            }
+        });
+        
         server.register({
             register: MrHorse,
             options : {
@@ -693,5 +711,16 @@ lab.experiment('Normal setup', function (done) {
             done();
         });
     });
-    
+
+    lab.test('parallel aggregate policy runs multiple policies when specified in array format', function (done) {
+
+        server.inject('/parallel-as-array', function (res) {
+            
+            Code.expect(res.statusCode).to.equal(200);
+            Code.expect(res.result.added).to.equal('this');
+            Code.expect(res.result.addedAnother).to.equal('that');
+            done();
+        });
+    });
+
 });

--- a/test/policies/postHandlerAnother.js
+++ b/test/policies/postHandlerAnother.js
@@ -1,0 +1,9 @@
+var postHandler = function (request, reply, callback) {
+
+    request.response.source.addedAnother = 'that';
+    callback(null, true);
+};
+
+postHandler.applyPoint = 'onPostHandler';
+
+module.exports = postHandler;

--- a/test/policies/timedCustomMessageEarly.js
+++ b/test/policies/timedCustomMessageEarly.js
@@ -1,0 +1,9 @@
+var timedCustomMessageEarly = function (request, reply, callback) {
+
+    setTimeout(function () {
+
+        callback(null, false, 'custom early');
+    }, 1);
+};
+
+module.exports = timedCustomMessageEarly;

--- a/test/policies/timedCustomMessageLate.js
+++ b/test/policies/timedCustomMessageLate.js
@@ -1,0 +1,9 @@
+var timedCustomMessageLate = function (request, reply, callback) {
+
+    setTimeout(function () {
+
+        callback(null, false, 'custom late');
+    }, 50);
+};
+
+module.exports = timedCustomMessageLate;


### PR DESCRIPTION
Here's `MrHorse.parallel`, currently sans documentation.  See tests for usage for now.  Happy to answer any questions about this!  Builds on top of work done in #15.  Related discussion: #11.

Short example config from tests,
```node
server.route({
    method : 'GET',
    path   : '/parallel-ok',
    handler: function (request, reply) {

        reply({
            handler: 'handler'
        });
    },
    config : {
        plugins: {
            policies: [ MrHorse.parallel('postHandler', 'postHandlerAnother') ]
        }
    }
});
```