### PR TITLE
Ignore duplicated policies based on configuration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -196,6 +196,9 @@ const loadPolicies = (server, options, next) => {
         if (match) {
             // Does this policy already exist
             if (data.names.indexOf(match[1]) !== -1) {
+                if (options.ignoreDuplicates) {
+                    return addPolicyNext();
+                }
                 server.log(['error'], 'Trying to add a duplicate policy: ' + match[1]);
                 return addPolicyNext(new Error('Trying to add a duplicate policy: ' + match[1]));
             }

--- a/test/index.js
+++ b/test/index.js
@@ -513,6 +513,15 @@ lab.experiment('Normal setup', function (done) {
 
     });
 
+    lab.test('ignores duplicate policies', function (done) {
+
+        server.plugins.mrhorse.loadPolicies(server, {policyDirectory: __dirname + '/policies', ignoreDuplicates: true}, function (err) {
+            Code.expect(err).to.not.exist();
+            done();
+        });
+
+    });
+
     lab.test('routes do not have to have a policy', function (done) {
 
         server.inject('/none', function (res) {


### PR DESCRIPTION
Hi Mark and co - 

We are trying to set up our environment to work with [Wallaby.js](https://www.wallabyjs.com), and are running into an error where Wallaby re-initializes the server using the same process, and mrhorse reports duplicated policies, as it should.

```bash
[Error] Runtime error: Error: Trying to add a duplicate policy: canCreateUser
```

I propose adding a configuration option called `ignoreDuplicates` that allows you to initialize mrhorse multiple times for use cases like this.