### PR TITLE
Helper functions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -307,7 +307,7 @@ exports.register = function register(server, options, next) {
 
 
 exports.register.attributes = {
-    pkg: pkg
+    pkg: require('../package.json')
 };
 
 /* Policy aggregation tools */

--- a/lib/index.js
+++ b/lib/index.js
@@ -177,6 +177,40 @@ _applyPoints.forEach((applyPoint) => {
     };
 });
 
+
+const addPolicy = (policyName, policy, server, options) => {
+    // Does this policy already exist
+    if (hasPolicy(policyName)) {
+        if (options.ignoreDuplicates) {
+            return;
+        }
+
+        throw new Error('Trying to add a duplicate policy: ' + policyName);
+    }
+
+    // Check if the apply point is correct
+    if (!hasValidApplyPoint(policy)) {
+        throw new Error('Trying to set incorrect applyPoint for the policy: ' + policy.applyPoint);
+    }
+
+    // going further, filling the policies vs application points list
+    if (policy.applyPoint === undefined || policy.applyPoint) {
+        const applyPoint = policy.applyPoint || options.defaultApplyPoint;
+
+        server.log(['info'], 'Adding a new policy called ' + policyName);
+        data[applyPoint][policyName] = policy;
+        data.rawPolicies[policyName] = policy;
+        data.names.push(policyName);
+
+        // connect the handler if this is the first pre policy
+        if (!data.setHandlers[applyPoint]) {
+            server.ext(applyPoint, handlers[applyPoint]);
+            data.setHandlers[applyPoint] = true;
+        }
+    }
+};
+
+
 const loadPolicies = (server, options, next) => {
 
     let match = null;
@@ -189,54 +223,43 @@ const loadPolicies = (server, options, next) => {
         return next();
     }
 
-    const addPolicy = (filename, addPolicyNext) => {
+    const loadPolicyFile = (filename, addPolicyNext) => {
 
         // Only looking for .js files in the policies folder
         match = filename.match(re);
         if (match) {
-            // Does this policy already exist
-            if (data.names.indexOf(match[1]) !== -1) {
-                if (options.ignoreDuplicates) {
-                    return addPolicyNext();
+
+            const policyData = require(Path.join(options.policyDirectory, filename));
+
+            try {
+                if (_.isPlainObject(policyData)) {
+                    _.each(policyData, (policy, policyName) => addPolicy(policyName, policy, server, options));
                 }
-                server.log(['error'], 'Trying to add a duplicate policy: ' + match[1]);
-                return addPolicyNext(new Error('Trying to add a duplicate policy: ' + match[1]));
-            }
-
-            // Add this policy function to the data object
-            const policy = require(Path.join(options.policyDirectory, filename));
-
-            // Check if the apply point is correct
-            if (!hasValidApplyPoint(policy)) {
-                server.log(['error'], 'Trying to set incorrect applyPoint for the policy: ' + policy.applyPoint);
-                return addPolicyNext(new Error('Trying to set incorrect applyPoint for the policy: ' + policy.applyPoint));
-            }
-
-            // going further, filling the policies vs application points list
-            if (policy.applyPoint === undefined || policy.applyPoint) {
-                const applyPoint = policy.applyPoint || options.defaultApplyPoint;
-
-                server.log(['info'], 'Adding a new policy called ' + match[1]);
-                data[applyPoint][match[1]] = policy;
-                data.rawPolicies[match[1]] = policy;
-                data.names.push(match[1]);
-
-                // connect the handler if this is the first pre policy
-                if (!data.setHandlers[applyPoint]) {
-                    server.ext(applyPoint, handlers[applyPoint]);
-                    data.setHandlers[applyPoint] = true;
+                else {
+                    addPolicy(match[1], policyData, server, options);
                 }
+            }
+            catch ( err ) {
+                server.log(['error'], err.message);
+                return addPolicyNext(err);
             }
         }
 
         addPolicyNext();
     };
 
-    Items.serial(policyFiles, addPolicy, (err) => {
+    Items.serial(policyFiles, loadPolicyFile, (err) => {
 
         next(err);
     });
 };
+
+
+const hasPolicy = ( policyName ) => {
+
+    return (data.names.indexOf(policyName) !== -1);
+};
+
 
 const reset = function reset() {
 
@@ -256,6 +279,7 @@ const reset = function reset() {
     });
 };
 
+
 exports.register = function register(server, options, next) {
 
     options.defaultApplyPoint = options.defaultApplyPoint || 'onPreHandler'; // default application point
@@ -265,6 +289,9 @@ exports.register = function register(server, options, next) {
     server.expose('loadPolicies', loadPolicies);
     server.expose('data', data);
     server.expose('reset', reset);
+    server.expose('orPolicy', exports.orPolicy);
+    server.expose('addPolicy', (policyName, policy) => addPolicy( policyName, policy, server, options ));
+    server.expose('hasPolicy', hasPolicy);
     server.expose('defaultApplyPoint', options.defaultApplyPoint);
 
     if (options.policyDirectory !== undefined) {
@@ -278,8 +305,12 @@ exports.register = function register(server, options, next) {
     }
 };
 
+
+const pkg = _.cloneDeep( require('../package.json') );
+pkg.name = 'mrhorse'; // drop-in replacement
+
 exports.register.attributes = {
-    pkg: require('../package.json')
+    pkg: pkg
 };
 
 /* Policy aggregation tools */
@@ -364,3 +395,30 @@ exports.parallel = function (/*policy1, policy2, [cb]*/) {
     // Here ya go!
     return aggregatePolicy;
 };
+
+
+exports.orPolicy = function () {
+
+    const args = Array.prototype.slice.call( arguments );
+
+    args.push(
+        ( ranPolicies, results, next ) => {
+
+            // successful if at least one policy was OK
+            const success = !_.every( ranPolicies, ( policyName ) => ( results[ policyName ].canContinue === false ) );
+
+            if ( success ) {
+                return next( null, true, null );
+            }
+
+            // find leftmost failed policy
+            const failed = _.find( results, { canContinue : false } );
+
+            return next( failed.err, false, failed.message );
+        }
+    );
+
+    return exports.parallel.apply( this, args );
+};
+
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -239,7 +239,7 @@ const loadPolicies = (server, options, next) => {
                     addPolicy(match[1], policyData, server, options);
                 }
             }
-            catch ( err ) {
+            catch (err) {
                 server.log(['error'], err.message);
                 return addPolicyNext(err);
             }
@@ -255,7 +255,7 @@ const loadPolicies = (server, options, next) => {
 };
 
 
-const hasPolicy = ( policyName ) => {
+const hasPolicy = (policyName) => {
 
     return (data.names.indexOf(policyName) !== -1);
 };
@@ -290,7 +290,7 @@ exports.register = function register(server, options, next) {
     server.expose('data', data);
     server.expose('reset', reset);
     server.expose('orPolicy', exports.orPolicy);
-    server.expose('addPolicy', (policyName, policy) => addPolicy( policyName, policy, server, options ));
+    server.expose('addPolicy', (policyName, policy) => addPolicy(policyName, policy, server, options));
     server.expose('hasPolicy', hasPolicy);
     server.expose('defaultApplyPoint', options.defaultApplyPoint);
 
@@ -305,9 +305,6 @@ exports.register = function register(server, options, next) {
     }
 };
 
-
-const pkg = _.cloneDeep( require('../package.json') );
-pkg.name = 'mrhorse'; // drop-in replacement
 
 exports.register.attributes = {
     pkg: pkg
@@ -399,26 +396,26 @@ exports.parallel = function (/*policy1, policy2, [cb]*/) {
 
 exports.orPolicy = function () {
 
-    const args = Array.prototype.slice.call( arguments );
+    const args = Array.prototype.slice.call(arguments);
 
     args.push(
-        ( ranPolicies, results, next ) => {
+        (ranPolicies, results, next) => {
 
             // successful if at least one policy was OK
-            const success = !_.every( ranPolicies, ( policyName ) => ( results[ policyName ].canContinue === false ) );
+            const success = !_.every(ranPolicies, (policyName) => (results[ policyName ].canContinue === false));
 
-            if ( success ) {
-                return next( null, true, null );
+            if (success) {
+                return next(null, true, null);
             }
 
             // find leftmost failed policy
-            const failed = _.find( results, { canContinue : false } );
+            const failed = _.find(results, { canContinue : false });
 
-            return next( failed.err, false, failed.message );
+            return next(failed.err, false, failed.message);
         }
     );
 
-    return exports.parallel.apply( this, args );
+    return exports.parallel.apply(this, args);
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -879,7 +879,7 @@ lab.experiment('Normal setup', function (done) {
     lab.test('programmatically added policy can be attached to a route', function (done) {
 
         const policyName = 'injectedPolicy';
-		var policyCalled = false;
+        var policyCalled = false;
 
         Code.expect(server.plugins.mrhorse.hasPolicy(policyName)).to.equal(false);
 
@@ -891,32 +891,32 @@ lab.experiment('Normal setup', function (done) {
 
         server.plugins.mrhorse.addPolicy(policyName, policy);
 
-		server.route({
-			method : 'GET',
-			path   : '/add-policy-test',
-			handler: function (request, reply) {
+        server.route({
+            method : 'GET',
+            path   : '/add-policy-test',
+            handler: function (request, reply) {
 
-				reply({
-					handler: 'handler'
-				});
-			},
-			config : {
-				plugins: {
-					policies: [
-						policyName
-					]
-				}
-			}
-		});
+                reply({
+                    handler: 'handler'
+                });
+            },
+            config : {
+                plugins: {
+                    policies: [
+                        policyName
+                    ]
+                }
+            }
+        });
 
-		Code.expect(policyCalled).to.equal(false);
+        Code.expect(policyCalled).to.equal(false);
 
-		server.inject('/add-policy-test', function (res) {
+        server.inject('/add-policy-test', function (res) {
 
-			Code.expect(res.statusCode).to.equal(200);
-			Code.expect(policyCalled).to.equal(true);
-			done();
-		});
+            Code.expect(res.statusCode).to.equal(200);
+            Code.expect(policyCalled).to.equal(true);
+            done();
+        });
 
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -879,7 +879,7 @@ lab.experiment('Normal setup', function (done) {
     lab.test('programmatically added policy can be attached to a route', function (done) {
 
         const policyName = 'injectedPolicy';
-		let policyCalled = false;
+		var policyCalled = false;
 
         Code.expect(server.plugins.mrhorse.hasPolicy(policyName)).to.equal(false);
 

--- a/test/index.js
+++ b/test/index.js
@@ -29,6 +29,18 @@ var server = null;
 
 lab.experiment('Non standard setups', function (done) {
 
+    lab.before(function (done) {
+        try {
+            fs.rmdirSync(__dirname + '/emptypolicies');
+            fs.unlinkSync(__dirname + '/incorrect-policies/incorrectApplyPoint.js');
+            fs.rmdirSync(__dirname + '/incorrect-policies');
+        }
+        catch( err ) { /* do nothing */ }
+
+        done();
+    });
+
+
     lab.beforeEach(function (done) {
 
         server = new Hapi.Server();
@@ -99,7 +111,7 @@ lab.experiment('Non standard setups', function (done) {
             }
 
             Code.expect(server.plugins.mrhorse.data.setHandlers.onPostHandler).to.equal(true);
-            Code.expect(Object.keys(server.plugins.mrhorse.data.onPostHandler).length).to.equal(10);
+            Code.expect(Object.keys(server.plugins.mrhorse.data.onPostHandler).length).to.equal(14);
 
             server.plugins.mrhorse.reset();
 
@@ -470,6 +482,78 @@ lab.experiment('Normal setup', function (done) {
             }
         });
 
+        server.route({
+            method : 'GET',
+            path   : '/or-first-ok',
+            handler: function (request, reply) {
+
+                reply({
+                    handler: 'handler'
+                });
+            },
+            config : {
+                plugins: {
+                    policies: [
+                        MrHorse.orPolicy( 'multiPolicyOkA', 'multiPolicyFailB' )
+                    ]
+                }
+            }
+        });
+
+        server.route({
+            method : 'GET',
+            path   : '/or-second-ok',
+            handler: function (request, reply) {
+
+                reply({
+                    handler: 'handler'
+                });
+            },
+            config : {
+                plugins: {
+                    policies: [
+                        MrHorse.orPolicy( 'multiPolicyFailA', 'multiPolicyOkB' )
+                    ]
+                }
+            }
+        });
+
+        server.route({
+            method : 'GET',
+            path   : '/or-both-ok',
+            handler: function (request, reply) {
+
+                reply({
+                    handler: 'handler'
+                });
+            },
+            config : {
+                plugins: {
+                    policies: [
+                        MrHorse.orPolicy( 'multiPolicyOkA', 'multiPolicyOkB' )
+                    ]
+                }
+            }
+        });
+
+        server.route({
+            method : 'GET',
+            path   : '/or-both-fail',
+            handler: function (request, reply) {
+
+                reply({
+                    handler: 'handler'
+                });
+            },
+            config : {
+                plugins: {
+                    policies: [
+                        MrHorse.orPolicy( 'multiPolicyFailA', 'multiPolicyFailB' )
+                    ]
+                }
+            }
+        });
+
         server.register({
             register: MrHorse,
             options : {
@@ -520,6 +604,15 @@ lab.experiment('Normal setup', function (done) {
             done();
         });
 
+    });
+
+    lab.test('loads multiple policies from a single file', function (done) {
+
+        Code.expect(server.plugins.mrhorse.hasPolicy('multiPolicyOkA')).to.equal(true);
+        Code.expect(server.plugins.mrhorse.hasPolicy('multiPolicyFailA')).to.equal(true);
+        Code.expect(server.plugins.mrhorse.hasPolicy('multiPolicyOkB')).to.equal(true);
+        Code.expect(server.plugins.mrhorse.hasPolicy('multiPolicyFailB')).to.equal(true);
+        done();
     });
 
     lab.test('routes do not have to have a policy', function (done) {
@@ -731,5 +824,54 @@ lab.experiment('Normal setup', function (done) {
             done();
         });
     });
+
+    lab.test('policy can be added programmatically', function (done) {
+        server.plugins.mrhorse.addPolicy('yetAnotherPolicy', (request, reply, callback) => callback(null, true));
+
+        Code.expect(server.plugins.mrhorse.hasPolicy('yetAnotherPolicy')).to.equal(true);
+        done();
+    });
+
+    lab.test('hasPolicy returns false on non-existent policies', function (done) {
+        Code.expect(server.plugins.mrhorse.hasPolicy('thisPolicyAbsolutelyDoesNotExist')).to.equal(false);
+        done();
+    });
+
+    lab.test('orPolicy creates a chain of policies in which only one must succeed (left)', function (done) {
+
+        server.inject('/or-first-ok', function (res) {
+
+            Code.expect(res.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    lab.test('orPolicy creates a chain of policies in which only one must succeed (right)', function (done) {
+
+        server.inject('/or-second-ok', function (res) {
+
+            Code.expect(res.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    lab.test('orPolicy creates a chain of policies in which both may succeed', function (done) {
+
+        server.inject('/or-both-ok', function (res) {
+
+            Code.expect(res.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    lab.test('orPolicy creates a chain of policies in which at least one must succeed', function (done) {
+
+        server.inject('/or-both-fail', function (res) {
+
+            Code.expect(res.statusCode).to.equal(403);
+            done();
+        });
+    });
+
 
 });

--- a/test/policies/multiPolicyFile.js
+++ b/test/policies/multiPolicyFile.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+
+    multiPolicyOkA : (request, reply, callback) => {
+
+        callback(null, true);
+    },
+
+    multiPolicyFailA : (request, reply, callback) => {
+
+        callback(null, false);
+    },
+
+    multiPolicyOkB : (request, reply, callback) => {
+
+        callback(null, true);
+    },
+
+    multiPolicyFailB : (request, reply, callback) => {
+
+        callback(null, false);
+    }
+
+};


### PR DESCRIPTION
Howdy,

Here are a couple of helpers that I think would be very helpful with MrHorse.

* Define a set of policies of which *at least one* must be satisfied: `MrHorse.orPolicy('policyName1', 'policyName2', ...)`
* Load multiple policies from a single file: `module.exports = { policyName1 : function() { ... }, policyName2 : ... };`
* Add policies programmatically: `server.plugins.mrhorse.addPolicy(policyName, policy)`
* Test whether policy exists: `server.plugins.mrhorse.hasPolicy(policyName)`

As far as I can tell, this is fully backward compatible and has 100% test coverage.