### PR TITLE
allow typescript files for policies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -214,7 +214,7 @@ const addPolicy = (policyName, policy, server, options) => {
 const loadPolicies = (server, options, next) => {
 
     let match = null;
-    const re = /(.+)\.js$/;
+    const re = /(.+)(\.js|\.ts)$/;
 
     options.defaultApplyPoint = options.defaultApplyPoint || 'onPreHandler'; // default application point
 


### PR DESCRIPTION
Hi,
I was wondering why policies wasn't applied on my project which is written in typescript (in dev mode).
Here is a quick fix to allow typescript project to use the plugin by whitelisting *.ts files for policies.
