### PR TITLE
build: upgrade hapi to scoped packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: node_js
 
 node_js:
   - 8
+  - 10
+  - 12
 
 sudo: false

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const _ = require('lodash');
-const Boom = require('boom');
+const Boom = require('@hapi/boom');
 const Fs = require('fs');
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const Path = require('path');
 
 const _applyPoints = ['onRequest',
@@ -302,11 +302,11 @@ exports.plugin.register = async function register(server, options) {
 
 
 /* Policy aggregation tools */
-exports.parallel = function (/*policy1, policy2, [cb]*/) {
+exports.parallel = function (...params/*policy1, policy2, [cb]*/) {
 
-    Hoek.assert(arguments.length, 'Requires at least one argument.');
+    Hoek.assert(params.length, 'Requires at least one argument.');
 
-    const args = Array.prototype.slice.call(arguments);
+    const args = Array.prototype.slice.call(params);
 
     // This error aggregator is used by default, giving priority to error responses
     // by the policies' listed order.
@@ -376,9 +376,9 @@ exports.parallel = function (/*policy1, policy2, [cb]*/) {
 };
 
 
-exports.orPolicy = function () {
+exports.orPolicy = function (...params) {
 
-    const args = Array.prototype.slice.call(arguments);
+    const args = Array.prototype.slice.call(params);
 
     args.push(
         (ranPolicies, results) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,1814 +1,1741 @@
 {
-  "name": "mrhorse",
-  "version": "3.0.1",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "accept": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/accept/-/accept-3.0.2.tgz",
-      "integrity": "sha512-bghLXFkCOsC1Y2TZ51etWfKDs6q249SAoHTZVfzWWdlZxoij+mgkj9AmUJWQpDY48TfnrTDIe43Xem4zdMe7mQ==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "hoek": "5.0.2"
-      }
-    },
-    "acorn": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
-      "dev": true
-    },
-    "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
-    },
-    "ajv": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
-      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
-      }
-    },
-    "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-      "dev": true
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
-    "ammo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.0.tgz",
-      "integrity": "sha512-6yoz9MXYV9sgCHrwprHWPxBaJ9/roQRfXzS//4JCNgKfPYcghFNwJQKBt6vWOoSGGRHsP6qsLJ+xtKStKJWdLQ==",
-      "dev": true,
-      "requires": {
-        "boom": "6.0.0",
-        "hoek": "5.0.2"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-6.0.0.tgz",
-          "integrity": "sha512-LYLa8BmiiOWjvxTMVh73lcZzd2E5yczrKvxAny1UuzO2tkarLrw4tdp3rdfmus3+YfKcZP0vRSM3Obh+fGK6eA==",
-          "dev": true,
-          "requires": {
-            "hoek": "5.0.2"
-          }
-        }
-      }
-    },
-    "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
-      "dev": true
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
-    },
-    "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "1.0.3"
-      }
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
-    },
-    "b64": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/b64/-/b64-4.0.0.tgz",
-      "integrity": "sha512-EhmUQodKB0sdzPPrbIWbGqA5cQeTWxYrAgNeeT1rLZWtD3tbNTnphz8J4vkXI3cPgBNlXBjzEbzDzq0Nwi4f9A==",
-      "dev": true
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
-      "dependencies": {
+    "name": "mrhorse",
+    "version": "3.0.1",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+                    "dev": true
+                }
+            }
+        },
+        "@hapi/accept": {
+            "version": "3.2.2",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/accept/-/accept-3.2.2.tgz",
+            "integrity": "sha1-OgM69nvoGWwj+PUaqHVmh7lyx8s=",
+            "dev": true,
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "@hapi/address": {
+            "version": "2.0.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/address/-/address-2.0.0.tgz",
+            "integrity": "sha1-nwVGnIjLL9Pc1iR3a1TulcMSEmo=",
+            "dev": true
+        },
+        "@hapi/ammo": {
+            "version": "3.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/ammo/-/ammo-3.1.0.tgz",
+            "integrity": "sha1-oygey2i/evL/ptD3ZWU2p9I3AO0=",
+            "dev": true,
+            "requires": {
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "@hapi/b64": {
+            "version": "4.2.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/b64/-/b64-4.2.0.tgz",
+            "integrity": "sha1-dt4MftduVb+kJwmk+s/olN1B10E=",
+            "dev": true,
+            "requires": {
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "@hapi/boom": {
+            "version": "7.4.2",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/boom/-/boom-7.4.2.tgz",
+            "integrity": "sha1-wWlXzQl5b2wb+0AxvcOdZtbXUMM=",
+            "requires": {
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "@hapi/bossy": {
+            "version": "4.1.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/bossy/-/bossy-4.1.1.tgz",
+            "integrity": "sha1-m3YH2y8vx+6m9rXaVbjRqkdXN1g=",
+            "dev": true,
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "6.x.x",
+                "@hapi/joi": "15.x.x"
+            }
+        },
+        "@hapi/bounce": {
+            "version": "1.3.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/bounce/-/bounce-1.3.0.tgz",
+            "integrity": "sha1-BZ8ZTfkFyloUEdQIA6Zl7hcFM+g=",
+            "dev": true,
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "@hapi/bourne": {
+            "version": "1.3.2",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/bourne/-/bourne-1.3.2.tgz",
+            "integrity": "sha1-CnCVreoGckPOMoPhtWuKj0U7JCo=",
+            "dev": true
+        },
+        "@hapi/call": {
+            "version": "5.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/call/-/call-5.1.0.tgz",
+            "integrity": "sha1-keTENDGAAxc9ltIR2Q01c2ozlF4=",
+            "dev": true,
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "@hapi/catbox": {
+            "version": "10.2.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/catbox/-/catbox-10.2.1.tgz",
+            "integrity": "sha1-riH7zdFuTf+AK2lp7i1rxRt+ESg=",
+            "dev": true,
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "6.x.x",
+                "@hapi/joi": "15.x.x",
+                "@hapi/podium": "3.x.x"
+            }
+        },
+        "@hapi/catbox-memory": {
+            "version": "4.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/catbox-memory/-/catbox-memory-4.1.0.tgz",
+            "integrity": "sha1-y1+69FxSvrRHZtrgGKKu57Q+nIg=",
+            "dev": true,
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "@hapi/code": {
+            "version": "5.3.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/code/-/code-5.3.1.tgz",
+            "integrity": "sha1-/EwvRfM9HCnxKnYJcy+L+mOkNUU=",
+            "dev": true,
+            "requires": {
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "@hapi/content": {
+            "version": "4.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/content/-/content-4.1.0.tgz",
+            "integrity": "sha1-UmVRaUnKCB6FpD6XwQWP9T/GlxQ=",
+            "dev": true,
+            "requires": {
+                "@hapi/boom": "7.x.x"
+            }
+        },
+        "@hapi/cryptiles": {
+            "version": "4.2.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/cryptiles/-/cryptiles-4.2.0.tgz",
+            "integrity": "sha1-0ivVr6VPPBo7lEpD2t/UxeV0f3I=",
+            "dev": true,
+            "requires": {
+                "@hapi/boom": "7.x.x"
+            }
+        },
+        "@hapi/eslint-config-hapi": {
+            "version": "12.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/eslint-config-hapi/-/eslint-config-hapi-12.1.0.tgz",
+            "integrity": "sha1-nqkqvoV64VgNkB4ZtCVL3UD9XXA=",
+            "dev": true
+        },
+        "@hapi/eslint-plugin-hapi": {
+            "version": "4.3.3",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/eslint-plugin-hapi/-/eslint-plugin-hapi-4.3.3.tgz",
+            "integrity": "sha1-+tBczJizWlmmYDVU6HfDb4PfEO4=",
+            "dev": true,
+            "requires": {
+                "@hapi/rule-capitalize-modules": "1.x.x",
+                "@hapi/rule-for-loop": "1.x.x",
+                "@hapi/rule-no-arrowception": "1.x.x",
+                "@hapi/rule-no-var": "1.x.x",
+                "@hapi/rule-scope-start": "2.x.x"
+            }
+        },
+        "@hapi/hapi": {
+            "version": "18.3.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/hapi/-/hapi-18.3.1.tgz",
+            "integrity": "sha1-k20eJFUbEUhuq9akl0vqTsISdmk=",
+            "dev": true,
+            "requires": {
+                "@hapi/accept": "3.x.x",
+                "@hapi/ammo": "3.x.x",
+                "@hapi/boom": "7.x.x",
+                "@hapi/bounce": "1.x.x",
+                "@hapi/call": "5.x.x",
+                "@hapi/catbox": "10.x.x",
+                "@hapi/catbox-memory": "4.x.x",
+                "@hapi/heavy": "6.x.x",
+                "@hapi/hoek": "6.x.x",
+                "@hapi/joi": "15.x.x",
+                "@hapi/mimos": "4.x.x",
+                "@hapi/podium": "3.x.x",
+                "@hapi/shot": "4.x.x",
+                "@hapi/somever": "2.x.x",
+                "@hapi/statehood": "6.x.x",
+                "@hapi/subtext": "6.x.x",
+                "@hapi/teamwork": "3.x.x",
+                "@hapi/topo": "3.x.x"
+            }
+        },
+        "@hapi/heavy": {
+            "version": "6.2.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/heavy/-/heavy-6.2.0.tgz",
+            "integrity": "sha1-tsMFeOHzCrbKF6gYdy8RsRFrqMw=",
+            "dev": true,
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "6.x.x",
+                "@hapi/joi": "15.x.x"
+            }
+        },
+        "@hapi/hoek": {
+            "version": "6.2.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/hoek/-/hoek-6.2.1.tgz",
+            "integrity": "sha1-06ZjKRWa+Hm/3wsM/yIpxDxaNFE="
+        },
+        "@hapi/iron": {
+            "version": "5.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/iron/-/iron-5.1.0.tgz",
+            "integrity": "sha1-w7NHg80Zt7iqvhG3KwzjeB/O4I0=",
+            "dev": true,
+            "requires": {
+                "@hapi/b64": "4.x.x",
+                "@hapi/boom": "7.x.x",
+                "@hapi/cryptiles": "4.x.x",
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "@hapi/joi": {
+            "version": "15.0.3",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/joi/-/joi-15.0.3.tgz",
+            "integrity": "sha1-6UVo/YWeXpRRJtVnXn3SGEhGOKc=",
+            "dev": true,
+            "requires": {
+                "@hapi/address": "2.x.x",
+                "@hapi/hoek": "6.x.x",
+                "@hapi/topo": "3.x.x"
+            }
+        },
+        "@hapi/lab": {
+            "version": "18.1.2",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/lab/-/lab-18.1.2.tgz",
+            "integrity": "sha1-mnTbYKMQ35Cj2MJC1wJLOC1hJFE=",
+            "dev": true,
+            "requires": {
+                "@hapi/bossy": "4.x.x",
+                "@hapi/eslint-config-hapi": "12.x.x",
+                "@hapi/eslint-plugin-hapi": "4.x.x",
+                "@hapi/hoek": "6.x.x",
+                "diff": "4.x.x",
+                "eslint": "5.x.x",
+                "espree": "5.x.x",
+                "find-rc": "4.x.x",
+                "handlebars": "4.x.x",
+                "json-stable-stringify": "1.x.x",
+                "json-stringify-safe": "5.x.x",
+                "mkdirp": "0.5.x",
+                "seedrandom": "2.x.x",
+                "source-map": "0.7.x",
+                "source-map-support": "0.5.x",
+                "supports-color": "6.x.x",
+                "will-call": "1.x.x"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.1.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/acorn/-/acorn-6.1.1.tgz",
+                    "integrity": "sha1-fSWuBbuK0fm2mRCOEJTs14hK3B8=",
+                    "dev": true
+                },
+                "acorn-jsx": {
+                    "version": "5.0.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+                    "integrity": "sha1-MqBk/ZJUKSFqCbFBECv90YX65A4=",
+                    "dev": true
+                },
+                "diff": {
+                    "version": "4.0.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/diff/-/diff-4.0.1.tgz",
+                    "integrity": "sha1-DGZ8tGfru1zqfxTxNcwtuneAqP8=",
+                    "dev": true
+                },
+                "espree": {
+                    "version": "5.0.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/espree/-/espree-5.0.1.tgz",
+                    "integrity": "sha1-XWUm+k/H8HiKXPdbFfMDI+L4H3o=",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^6.0.7",
+                        "acorn-jsx": "^5.0.0",
+                        "eslint-visitor-keys": "^1.0.0"
+                    }
+                },
+                "find-rc": {
+                    "version": "4.0.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/find-rc/-/find-rc-4.0.0.tgz",
+                    "integrity": "sha1-meQ8Wgx16dOIfSHssx73SSNXKqM=",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@hapi/mimos": {
+            "version": "4.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/mimos/-/mimos-4.1.0.tgz",
+            "integrity": "sha1-jDNFyjtwwOEOfp418OAdMUwtTjI=",
+            "dev": true,
+            "requires": {
+                "@hapi/hoek": "6.x.x",
+                "mime-db": "1.x.x"
+            }
+        },
+        "@hapi/nigel": {
+            "version": "3.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/nigel/-/nigel-3.1.0.tgz",
+            "integrity": "sha1-iPeCIPTwIqW9HWG1lQU2eGFCVZU=",
+            "dev": true,
+            "requires": {
+                "@hapi/hoek": "6.x.x",
+                "@hapi/vise": "3.x.x"
+            }
+        },
+        "@hapi/pez": {
+            "version": "4.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/pez/-/pez-4.1.0.tgz",
+            "integrity": "sha1-l6iOXRnnVu+9JOX1g9WfqNsdbLo=",
+            "dev": true,
+            "requires": {
+                "@hapi/b64": "4.x.x",
+                "@hapi/boom": "7.x.x",
+                "@hapi/content": "4.x.x",
+                "@hapi/hoek": "6.x.x",
+                "@hapi/nigel": "3.x.x"
+            }
+        },
+        "@hapi/podium": {
+            "version": "3.4.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/podium/-/podium-3.4.0.tgz",
+            "integrity": "sha1-NQsqk+sTuLfil+W82LH+om41lgc=",
+            "dev": true,
+            "requires": {
+                "@hapi/hoek": "6.x.x",
+                "@hapi/joi": "15.x.x"
+            }
+        },
+        "@hapi/rule-capitalize-modules": {
+            "version": "1.2.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/rule-capitalize-modules/-/rule-capitalize-modules-1.2.0.tgz",
+            "integrity": "sha1-U/VuRtDK9343IYOnA/e2GLiXLLM=",
+            "dev": true
+        },
+        "@hapi/rule-for-loop": {
+            "version": "1.2.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/rule-for-loop/-/rule-for-loop-1.2.0.tgz",
+            "integrity": "sha1-WWocttks/bMFRhKf7CbT22kl6HI=",
+            "dev": true
+        },
+        "@hapi/rule-no-arrowception": {
+            "version": "1.1.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/rule-no-arrowception/-/rule-no-arrowception-1.1.1.tgz",
+            "integrity": "sha1-1dAq71ppqKQeVd6mBe2tOQ0kRh0=",
+            "dev": true
+        },
+        "@hapi/rule-no-var": {
+            "version": "1.1.3",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/rule-no-var/-/rule-no-var-1.1.3.tgz",
+            "integrity": "sha1-gmR27IZR5QbR116zklaLK0htgCI=",
+            "dev": true
+        },
+        "@hapi/rule-scope-start": {
+            "version": "2.2.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/rule-scope-start/-/rule-scope-start-2.2.0.tgz",
+            "integrity": "sha1-Xcho5CoA0WrZuBquGsDuaCxjsgs=",
+            "dev": true
+        },
+        "@hapi/shot": {
+            "version": "4.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/shot/-/shot-4.1.0.tgz",
+            "integrity": "sha1-5WS/VHTZMulHvEirNf9WXU4b9Xs=",
+            "dev": true,
+            "requires": {
+                "@hapi/hoek": "6.x.x",
+                "@hapi/joi": "15.x.x"
+            }
+        },
+        "@hapi/somever": {
+            "version": "2.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/somever/-/somever-2.1.0.tgz",
+            "integrity": "sha1-RszyqFq3djWYKvFapKKMhHcXvb8=",
+            "dev": true,
+            "requires": {
+                "@hapi/bounce": "1.x.x",
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "@hapi/statehood": {
+            "version": "6.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/statehood/-/statehood-6.1.0.tgz",
+            "integrity": "sha1-JoHHONgWKB1qWQKGBUyLnneRFvw=",
+            "dev": true,
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/bounce": "1.x.x",
+                "@hapi/bourne": "1.x.x",
+                "@hapi/cryptiles": "4.x.x",
+                "@hapi/hoek": "6.x.x",
+                "@hapi/iron": "5.x.x",
+                "@hapi/joi": "15.x.x"
+            }
+        },
+        "@hapi/subtext": {
+            "version": "6.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/subtext/-/subtext-6.1.0.tgz",
+            "integrity": "sha1-WAx+DP9TR6hHkBg0bXLHU+6GEcY=",
+            "dev": true,
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/bourne": "1.x.x",
+                "@hapi/content": "4.x.x",
+                "@hapi/hoek": "6.x.x",
+                "@hapi/pez": "4.x.x",
+                "@hapi/wreck": "15.x.x"
+            }
+        },
+        "@hapi/teamwork": {
+            "version": "3.3.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/teamwork/-/teamwork-3.3.0.tgz",
+            "integrity": "sha1-9sOLggcl3HVz6Vzk/tbxIcBuYNM=",
+            "dev": true
+        },
+        "@hapi/topo": {
+            "version": "3.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/topo/-/topo-3.1.0.tgz",
+            "integrity": "sha1-XEfNljfClT2xhaqVeie8sqi3pvg=",
+            "dev": true,
+            "requires": {
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "@hapi/vise": {
+            "version": "3.1.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/vise/-/vise-3.1.0.tgz",
+            "integrity": "sha1-T6cbnnUvNeVRkRXHOkdHmnN1tEU=",
+            "dev": true,
+            "requires": {
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "@hapi/wreck": {
+            "version": "15.0.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@hapi/wreck/-/wreck-15.0.1.tgz",
+            "integrity": "sha1-ufiBllp+ZJqP/+beJbpBlz7ShBU=",
+            "dev": true,
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/bourne": "1.x.x",
+                "@hapi/hoek": "6.x.x"
+            }
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
+            }
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "astral-regex": {
+            "version": "1.0.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/astral-regex/-/astral-regex-1.0.0.tgz",
+            "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
+            "dev": true
+        },
+        "async": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "camelcase": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+            "dev": true,
+            "optional": true
+        },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
+            }
+        },
         "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+            "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                }
+            }
         },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+        "cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "^2.0.0"
+            }
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "big-time": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/big-time/-/big-time-2.0.0.tgz",
-      "integrity": "sha512-OXsmBxlRLwUc65MLta2EOyMTLcjZQkxHkJ81lVPeyVqZag8zhUfKRYIbF3E/IW/LWR8kf8a1GlRYkBXKVGqJOw==",
-      "dev": true
-    },
-    "boom": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
-      "integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
-      "requires": {
-        "hoek": "5.0.2"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.2.tgz",
-          "integrity": "sha512-NA10UYP9ufCtY2qYGkZktcQXwVyYK4zK0gkaFSB96xhtlo6V8tKXdQgx8eHolQTRemaW0uLn8BhjhwqrOU+QLQ=="
-        }
-      }
-    },
-    "bossy": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bossy/-/bossy-4.0.1.tgz",
-      "integrity": "sha512-IrXZdXnDrjfk9ZVtnnmehlcTGK/KRqUJuNZJteMGU2/cJdXC6yWf2yhkAAbAgjOTsJJHXdlYloTeFH1ZgRNllw==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "hoek": "5.0.2",
-        "joi": "13.0.2"
-      }
-    },
-    "bounce": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.0.tgz",
-      "integrity": "sha512-8syCGe8B2/WC53118/F/tFy5aW00j+eaGPXmAUP7iBhxc+EBZZxS1vKelWyBCH6IqojgS2t1gF0glH30qAJKEw==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "hoek": "5.0.2"
-      }
-    },
-    "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "call": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/call/-/call-5.0.1.tgz",
-      "integrity": "sha512-ollfFPSshiuYLp7AsrmpkQJ/PxCi6AzV81rCjBwWhyF2QGyUY/vPDMzoh4aUcWyucheRglG2LaS5qkIEfLRh6A==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "hoek": "5.0.2"
-      }
-    },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "0.2.0"
-      }
-    },
-    "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-      "dev": true
-    },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true,
-      "optional": true
-    },
-    "catbox": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/catbox/-/catbox-10.0.2.tgz",
-      "integrity": "sha512-cTQTQeKMhWHU0lX8CADE3g1koGJu+AlcWFzAjMX/8P+XbkScGYw3tJsQpe2Oh8q68vOQbOLacz9k+6V/F3Z9DA==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "bounce": "1.2.0",
-        "hoek": "5.0.2",
-        "joi": "13.0.2"
-      }
-    },
-    "catbox-memory": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-3.1.1.tgz",
-      "integrity": "sha512-fl6TI/uneeUb9NGClKWZWkpCZQrkPmuVz/Jaqqb15vqW6KGfJ/vMP/ZMp8VgAkyTrrRvFHbFcS67sbU7EkvbhQ==",
-      "dev": true,
-      "requires": {
-        "big-time": "2.0.0",
-        "boom": "7.1.1",
-        "hoek": "5.0.2"
-      }
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
-    },
-    "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.4.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        }
-      }
-    },
-    "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-      "dev": true
-    },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
-    },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "2.0.0"
-      }
-    },
-    "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "code": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/code/-/code-5.1.2.tgz",
-      "integrity": "sha512-Typ0BuWOKPGNOY9M7hBDY60J9uSPok4Y7hhtTG/3Cpqg0/AhauZSWax0Mb0lZuzm89w1YgVvl8BTrBW/4Sw6sw==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.2.tgz",
-          "integrity": "sha512-NA10UYP9ufCtY2qYGkZktcQXwVyYK4zK0gkaFSB96xhtlo6V8tKXdQgx8eHolQTRemaW0uLn8BhjhwqrOU+QLQ==",
-          "dev": true
-        }
-      }
-    },
-    "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
-      }
-    },
-    "content": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/content/-/content-4.0.3.tgz",
-      "integrity": "sha512-BrMfT1xXZHaXyPT/sneXc3IQzh8uL15JWV1R5tU0xo4sBGjF7BN+IRi9WoQLSbfNEs7bJ3E69rjxBKg/RL7lOQ==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1"
-      }
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
-    },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
-    },
-    "cryptiles": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.1.tgz",
-      "integrity": "sha512-YuQUPbcOmaZsdvxJZ25DCA1W+lLIRoPJKBDKin+St1RCYEERSfoe1d25B1MvWNHN3e8SpFSVsqYvEUjp8J9H2w==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1"
-      }
-    },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true,
-      "optional": true
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
-      }
-    },
-    "diff": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
-      "dev": true
-    },
-    "doctrine": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2"
-      }
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "eslint-config-hapi": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-11.1.0.tgz",
-      "integrity": "sha512-fCw0uLgkZLQBqYu/lR5MA6cXB+D4c2EEtzrVmhHbGQq3iRCFSaUEOE/N4Sujd1Qh5jkaUc0/kuB/gdv2upt5aQ==",
-      "dev": true
-    },
-    "eslint-plugin-hapi": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-4.1.0.tgz",
-      "integrity": "sha512-z1yUoSWArx6pXaC0FoWRFpqjbHn8QWonJiTVhJmiC14jOAT7FZKdKWCkhM4jQrgrkEK9YEv3p2HuzSf5dtWmuQ==",
-      "dev": true,
-      "requires": {
-        "hapi-capitalize-modules": "1.1.6",
-        "hapi-for-you": "1.0.0",
-        "hapi-no-var": "1.0.1",
-        "hapi-scope-start": "2.1.1",
-        "no-arrowception": "1.0.0"
-      }
-    },
-    "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
-      }
-    },
-    "espree": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.2.1",
-        "acorn-jsx": "3.0.1"
-      }
-    },
-    "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
-    },
-    "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0"
-      }
-    },
-    "esrecurse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
-      }
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
-    },
-    "external-editor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
-      "dev": true,
-      "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.19",
-        "tmp": "0.0.33"
-      }
-    },
-    "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-      "dev": true
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
-    },
-    "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
-    },
-    "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
-      }
-    },
-    "find-rc": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/find-rc/-/find-rc-3.0.1.tgz",
-      "integrity": "sha1-VKQXg3DxC8k3H6jRssKAmir6DM4=",
-      "dev": true
-    },
-    "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-      "dev": true,
-      "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
-    },
-    "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
-    },
-    "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
-      }
-    },
-    "hapi": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/hapi/-/hapi-17.2.0.tgz",
-      "integrity": "sha512-zw2tqNimjT+qglgUNGNpeweHJ5To1xUcJcfGKsG5dWiTzwkEZtmtHJ8mBIvxuuZ3Buu4xkAGj0yWrrR95FVqQQ==",
-      "dev": true,
-      "requires": {
-        "accept": "3.0.2",
-        "ammo": "3.0.0",
-        "boom": "7.1.1",
-        "bounce": "1.2.0",
-        "call": "5.0.1",
-        "catbox": "10.0.2",
-        "catbox-memory": "3.1.1",
-        "heavy": "6.1.0",
-        "hoek": "5.0.2",
-        "joi": "13.0.2",
-        "mimos": "4.0.0",
-        "podium": "3.1.2",
-        "shot": "4.0.4",
-        "statehood": "6.0.5",
-        "subtext": "6.0.7",
-        "teamwork": "3.0.1",
-        "topo": "3.0.0"
-      }
-    },
-    "hapi-capitalize-modules": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
-      "integrity": "sha1-eZEXFBXhXmqjIx5k3ac8gUZmUxg=",
-      "dev": true
-    },
-    "hapi-for-you": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hapi-for-you/-/hapi-for-you-1.0.0.tgz",
-      "integrity": "sha1-02L77o172pwseAHiB+WlzRoLans=",
-      "dev": true
-    },
-    "hapi-no-var": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hapi-no-var/-/hapi-no-var-1.0.1.tgz",
-      "integrity": "sha512-kk2xyyTzI+eQ/oA1rO4eVdCpYsrPHVERHa6+mTHD08XXFLaAkkaEs6reMg1VyqGh2o5xPt//DO4EhCacLx/cRA==",
-      "dev": true
-    },
-    "hapi-scope-start": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-2.1.1.tgz",
-      "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI=",
-      "dev": true
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
-    "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
-    },
-    "heavy": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/heavy/-/heavy-6.1.0.tgz",
-      "integrity": "sha512-TKS9DC9NOTGulHQI31Lx+bmeWmNOstbJbGMiN3pX6bF+Zc2GKSpbbym4oasNnB6yPGkqJ9TQXXYDGohqNSJRxA==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "hoek": "5.0.2",
-        "joi": "13.0.2"
-      }
-    },
-    "hoek": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.2.tgz",
-      "integrity": "sha512-NA10UYP9ufCtY2qYGkZktcQXwVyYK4zK0gkaFSB96xhtlo6V8tKXdQgx8eHolQTRemaW0uLn8BhjhwqrOU+QLQ=="
-    },
-    "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
-    },
-    "ignore": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
-      "dev": true
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.3.0",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.1.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.4",
-        "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
-      }
-    },
-    "iron": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.4.tgz",
-      "integrity": "sha512-7iQ5/xFMIYaNt9g2oiNiWdhrOTdRUMFaWENUd0KghxwPUhrIH8DUY8FEyLNTTzf75jaII+jMexLdY/2HfV61RQ==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "cryptiles": "4.1.1",
-        "hoek": "5.0.2"
-      }
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.1"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "isemail": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.0.0.tgz",
-      "integrity": "sha512-rz0ng/c+fX+zACpLgDB8fnUQ845WSU06f4hlhk4K8TJxmR6f5hyvitu9a9JdMD7aq/P4E0XdG1uaab2OiXgHlA==",
-      "dev": true,
-      "requires": {
-        "punycode": "2.1.0"
-      }
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "items": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
-    },
-    "joi": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.0.2.tgz",
-      "integrity": "sha512-kVka3LaHQyENvcMW4WJPSepGM43oCofcKxfs9HbbKd/FrwBAAt4lNNTPKOzSMmV53GIspmNO4U3O2TzoGvxxCA==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2",
-        "isemail": "3.0.0",
-        "topo": "3.0.0"
-      }
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
-    },
-    "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
-      }
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
-    },
-    "lab": {
-      "version": "15.1.2",
-      "resolved": "https://registry.npmjs.org/lab/-/lab-15.1.2.tgz",
-      "integrity": "sha512-W7CnvFw/IOqLjeB9w66NIJbSpALEZyflt8HxD5Gp+kIvIRsG1vhX3WH9SCjsGR0o9T6FL//1vwt0pRJjwomf+Q==",
-      "dev": true,
-      "requires": {
-        "bossy": "4.0.1",
-        "diff": "3.4.0",
-        "eslint": "4.9.0",
-        "eslint-config-hapi": "11.1.0",
-        "eslint-plugin-hapi": "4.1.0",
-        "espree": "3.5.2",
-        "find-rc": "3.0.1",
-        "handlebars": "4.0.11",
-        "hoek": "5.0.2",
-        "json-stable-stringify": "1.0.1",
-        "json-stringify-safe": "5.0.1",
-        "mkdirp": "0.5.1",
-        "seedrandom": "2.4.3",
-        "source-map": "0.6.1",
-        "source-map-support": "0.5.0",
-        "supports-color": "4.4.0"
-      },
-      "dependencies": {
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
+        },
+        "cliui": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
+                "wordwrap": "0.0.2"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "color-convert": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "dev": true,
+            "requires": {
+                "color-name": "^1.1.1"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true,
+            "optional": true
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
         "eslint": {
-          "version": "4.9.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.9.0.tgz",
-          "integrity": "sha1-doedJ0BoJhsZH+Dy9Wx0wvQgjos=",
-          "dev": true,
-          "requires": {
-            "ajv": "5.5.1",
-            "babel-code-frame": "6.26.0",
-            "chalk": "2.3.0",
-            "concat-stream": "1.6.0",
-            "cross-spawn": "5.1.0",
-            "debug": "3.1.0",
-            "doctrine": "2.0.2",
-            "eslint-scope": "3.7.1",
-            "espree": "3.5.2",
-            "esquery": "1.0.0",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "2.0.0",
-            "functional-red-black-tree": "1.0.1",
-            "glob": "7.1.2",
-            "globals": "9.18.0",
-            "ignore": "3.3.7",
-            "imurmurhash": "0.1.4",
-            "inquirer": "3.3.0",
-            "is-resolvable": "1.0.0",
-            "js-yaml": "3.10.0",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "natural-compare": "1.4.0",
-            "optionator": "0.8.2",
-            "path-is-inside": "1.0.2",
-            "pluralize": "7.0.0",
-            "progress": "2.0.0",
-            "require-uncached": "1.0.3",
-            "semver": "5.4.1",
-            "strip-ansi": "4.0.0",
-            "strip-json-comments": "2.0.1",
-            "table": "4.0.2",
-            "text-table": "0.2.0"
-          }
+            "version": "5.16.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/eslint/-/eslint-5.16.0.tgz",
+            "integrity": "sha1-oeOsGq5KP72Clvz496tzFMu2q+o=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "ajv": "^6.9.1",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^4.0.1",
+                "doctrine": "^3.0.0",
+                "eslint-scope": "^4.0.3",
+                "eslint-utils": "^1.3.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^5.0.1",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^5.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.0.0",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^6.2.2",
+                "js-yaml": "^3.13.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.11",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.1",
+                "semver": "^5.5.1",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^5.2.3",
+                "text-table": "^0.2.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.1.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/acorn/-/acorn-6.1.1.tgz",
+                    "integrity": "sha1-fSWuBbuK0fm2mRCOEJTs14hK3B8=",
+                    "dev": true
+                },
+                "acorn-jsx": {
+                    "version": "5.0.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+                    "integrity": "sha1-MqBk/ZJUKSFqCbFBECv90YX65A4=",
+                    "dev": true
+                },
+                "ajv": {
+                    "version": "6.10.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ajv/-/ajv-6.10.0.tgz",
+                    "integrity": "sha1-kNDVRDnaWHzX6EO/twRfUL0ivfE=",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ansi-escapes": {
+                    "version": "3.2.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+                    "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chardet": {
+                    "version": "0.7.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/chardet/-/chardet-0.7.0.tgz",
+                    "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "doctrine": {
+                    "version": "3.0.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/doctrine/-/doctrine-3.0.0.tgz",
+                    "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2"
+                    }
+                },
+                "eslint-scope": {
+                    "version": "4.0.3",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/eslint-scope/-/eslint-scope-4.0.3.tgz",
+                    "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.1.0",
+                        "estraverse": "^4.1.1"
+                    }
+                },
+                "espree": {
+                    "version": "5.0.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/espree/-/espree-5.0.1.tgz",
+                    "integrity": "sha1-XWUm+k/H8HiKXPdbFfMDI+L4H3o=",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^6.0.7",
+                        "acorn-jsx": "^5.0.0",
+                        "eslint-visitor-keys": "^1.0.0"
+                    }
+                },
+                "esquery": {
+                    "version": "1.0.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/esquery/-/esquery-1.0.1.tgz",
+                    "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
+                    "dev": true,
+                    "requires": {
+                        "estraverse": "^4.0.0"
+                    }
+                },
+                "external-editor": {
+                    "version": "3.0.3",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/external-editor/-/external-editor-3.0.3.tgz",
+                    "integrity": "sha1-WGbbKal4Jtvkvzr9JAcOrZ6kOic=",
+                    "dev": true,
+                    "requires": {
+                        "chardet": "^0.7.0",
+                        "iconv-lite": "^0.4.24",
+                        "tmp": "^0.0.33"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+                    "dev": true
+                },
+                "file-entry-cache": {
+                    "version": "5.0.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+                    "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
+                    "dev": true,
+                    "requires": {
+                        "flat-cache": "^2.0.1"
+                    }
+                },
+                "flat-cache": {
+                    "version": "2.0.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/flat-cache/-/flat-cache-2.0.1.tgz",
+                    "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
+                    "dev": true,
+                    "requires": {
+                        "flatted": "^2.0.0",
+                        "rimraf": "2.6.3",
+                        "write": "1.0.3"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                },
+                "ignore": {
+                    "version": "4.0.6",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+                    "dev": true
+                },
+                "inquirer": {
+                    "version": "6.3.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/inquirer/-/inquirer-6.3.1.tgz",
+                    "integrity": "sha1-ekE7XnlQgRATo9tJHGHR87d26Oc=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^3.2.0",
+                        "chalk": "^2.4.2",
+                        "cli-cursor": "^2.1.0",
+                        "cli-width": "^2.0.0",
+                        "external-editor": "^3.0.3",
+                        "figures": "^2.0.0",
+                        "lodash": "^4.17.11",
+                        "mute-stream": "0.0.7",
+                        "run-async": "^2.2.0",
+                        "rxjs": "^6.4.0",
+                        "string-width": "^2.1.0",
+                        "strip-ansi": "^5.1.0",
+                        "through": "^2.3.6"
+                    },
+                    "dependencies": {
+                        "chalk": {
+                            "version": "2.4.2",
+                            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+                            "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "^3.2.1",
+                                "escape-string-regexp": "^1.0.5",
+                                "supports-color": "^5.3.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                            "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
+                            }
+                        }
+                    }
+                },
+                "js-yaml": {
+                    "version": "3.13.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/js-yaml/-/js-yaml-3.13.1.tgz",
+                    "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+                    "dev": true
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/rimraf/-/rimraf-2.6.3.tgz",
+                    "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    },
+                    "dependencies": {
+                        "glob": {
+                            "version": "7.1.4",
+                            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/glob/-/glob-7.1.4.tgz",
+                            "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+                            "dev": true,
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            }
+                        }
+                    }
+                },
+                "semver": {
+                    "version": "5.7.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/semver/-/semver-5.7.0.tgz",
+                    "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws=",
+                    "dev": true
+                },
+                "slice-ansi": {
+                    "version": "2.1.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/slice-ansi/-/slice-ansi-2.1.0.tgz",
+                    "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "astral-regex": "^1.0.0",
+                        "is-fullwidth-code-point": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "table": {
+                    "version": "5.3.3",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/table/-/table-5.3.3.tgz",
+                    "integrity": "sha1-6uVgyQQ3Mxt0IA4BFIejNEK9KLQ=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.9.1",
+                        "lodash": "^4.17.11",
+                        "slice-ansi": "^2.1.0",
+                        "string-width": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "3.1.0",
+                            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
+                            "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+                            "dev": true,
+                            "requires": {
+                                "emoji-regex": "^7.0.1",
+                                "is-fullwidth-code-point": "^2.0.0",
+                                "strip-ansi": "^5.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                            "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
+                            }
+                        }
+                    }
+                },
+                "write": {
+                    "version": "1.0.3",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/write/-/write-1.0.3.tgz",
+                    "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
+                    "dev": true,
+                    "requires": {
+                        "mkdirp": "^0.5.1"
+                    }
+                }
+            }
+        },
+        "eslint-utils": {
+            "version": "1.3.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/eslint-utils/-/eslint-utils-1.3.1.tgz",
+            "integrity": "sha1-moUbqJ7nxGA0b5fPiTnHKYgn5RI=",
+            "dev": true
+        },
+        "eslint-visitor-keys": {
+            "version": "1.0.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+            "integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+            "dev": true
+        },
+        "esrecurse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+            "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+            "dev": true,
+            "requires": {
+                "estraverse": "^4.1.0",
+                "object-assign": "^4.0.1"
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.5"
+            }
+        },
+        "flatted": {
+            "version": "2.0.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/flatted/-/flatted-2.0.0.tgz",
+            "integrity": "sha1-VRIrZTbqSWtLRIk+4mCBQdENmRY=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
         },
         "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-          "dev": true
-        }
-      }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
-      "optional": true
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
-    },
-    "mime-db": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.32.0.tgz",
-      "integrity": "sha512-+ZWo/xZN40Tt6S+HyakUxnSOgff+JEdaneLWIm0Z6LmpCn5DMcZntLyUY5c/rTDog28LhXLKOUZKoTxTCAdBVw==",
-      "dev": true
-    },
-    "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
-    },
-    "mimos": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimos/-/mimos-4.0.0.tgz",
-      "integrity": "sha512-JvlvRLqGIlk+AYypWrbrDmhsM+6JVx/xBM5S3AMwTBz1trPCEoPN/swO2L4Wu653fL7oJdgk8DMQyG/Gq3JkZg==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2",
-        "mime-db": "1.32.0"
-      }
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
-    "natural-compare": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "nigel": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.0.tgz",
-      "integrity": "sha512-ufFVFCe1zS/pfIQzQNa5uJxB8v8IcVTUn1zyPvQwb4CQGRxxBfdQPSXpEnI6ZzIwbV5L+GuAoRhYgcVSvTO7fA==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2",
-        "vise": "3.0.0"
-      }
-    },
-    "no-arrowception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/no-arrowception/-/no-arrowception-1.0.0.tgz",
-      "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "1.1.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
-      }
-    },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
-    },
-    "pez": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pez/-/pez-4.0.1.tgz",
-      "integrity": "sha512-0c/SoW5MY7lPdc5U1Q/ixyjLZbluGWJonHVmn4mKwSq7vgO9+a9WzoCopHubIwkot6Q+fevNVElaA+1M9SqHrA==",
-      "dev": true,
-      "requires": {
-        "b64": "4.0.0",
-        "boom": "7.1.1",
-        "content": "4.0.3",
-        "hoek": "5.0.2",
-        "nigel": "3.0.0"
-      }
-    },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "2.0.4"
-      }
-    },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
-    },
-    "podium": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/podium/-/podium-3.1.2.tgz",
-      "integrity": "sha512-18VrjJAduIdPv7d9zWsfmKxTj3cQTYC5Pv5gtKxcWujYBpGbV+mhNSPYhlHW5xeWoazYyKfB9FEsPT12r5rY1A==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2",
-        "joi": "13.0.2"
-      }
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
-    },
-    "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
-    "punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-      "dev": true
-    },
-    "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
-      }
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
-    },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      }
-    },
-    "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-      "dev": true
-    },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
-      }
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
-    },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2"
-      }
-    },
-    "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "2.1.0"
-      }
-    },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
-      "requires": {
-        "rx-lite": "4.0.8"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
-    },
-    "seedrandom": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
-      "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=",
-      "dev": true
-    },
-    "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "shot": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/shot/-/shot-4.0.4.tgz",
-      "integrity": "sha512-V8wHSJSNqt8ZIgdbTQCFIrp5BwBH+tsFLNBL1REmkFN/0PJdmzUBQscZqsbdSvdLc+Qxq7J5mcwzai66vs3ozA==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2",
-        "joi": "13.0.2"
-      }
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
-    },
-    "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0"
-      }
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
-      "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
-      "dev": true,
-      "requires": {
-        "source-map": "0.6.1"
-      }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
-    "statehood": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.5.tgz",
-      "integrity": "sha512-HPa8qT5sGTBVn1Fc9czBYR1oo7gBaay3ysnb04cvcF80YrDIV7880KpjmMj54j7CrFuQFfgMRb44QCRxRmAdTg==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "bounce": "1.2.0",
-        "cryptiles": "4.1.1",
-        "hoek": "5.0.2",
-        "iron": "5.0.4",
-        "joi": "13.0.2"
-      }
-    },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        }
-      }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
-    },
-    "subtext": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/subtext/-/subtext-6.0.7.tgz",
-      "integrity": "sha512-IcJUvRjeR+NB437Iq+LORFNJW4L6Knqkj3oQrBrkdhIaS2VKJvx/9aYEq7vi+PEx5/OuehOL/40SkSZotLi/MA==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "content": "4.0.3",
-        "hoek": "5.0.2",
-        "pez": "4.0.1",
-        "wreck": "14.0.2"
-      }
-    },
-    "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-      "dev": true,
-      "requires": {
-        "has-flag": "2.0.0"
-      }
-    },
-    "table": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-      "dev": true,
-      "requires": {
-        "ajv": "5.5.1",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
-        "lodash": "4.17.4",
-        "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
-      }
-    },
-    "teamwork": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/teamwork/-/teamwork-3.0.1.tgz",
-      "integrity": "sha512-hEkJIpDOfOYe9NYaLFk00zQbzZeKNCY8T2pRH3I13Y1mJwxaSQ6NEsjY5rCp+11ezCiZpWGoGFTbOuhg4qKevQ==",
-      "dev": true
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "1.0.2"
-      }
-    },
-    "topo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
-      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2"
-      }
-    },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-      "dev": true
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
-      },
-      "dependencies": {
+            "version": "11.12.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+            "dev": true
+        },
+        "handlebars": {
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+            "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+            "dev": true,
+            "requires": {
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": ">=0.0.4"
+                    }
+                }
+            }
+        },
+        "has-flag": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+            "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+            "dev": true
+        },
+        "import-fresh": {
+            "version": "3.0.0",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/import-fresh/-/import-fresh-3.0.0.tgz",
+            "integrity": "sha1-o9iX9CDKsOZxI2iX91vBS0iFw5A=",
+            "dev": true,
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+                    "dev": true
+                }
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true,
+            "optional": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
+            "requires": {
+                "jsonify": "~0.0.0"
+            }
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "is-buffer": "^1.1.5"
+            }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true,
+            "optional": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            }
+        },
+        "lodash": {
+            "version": "4.17.4",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+            "dev": true,
+            "optional": true
+        },
+        "mime-db": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.32.0.tgz",
+            "integrity": "sha512-+ZWo/xZN40Tt6S+HyakUxnSOgff+JEdaneLWIm0Z6LmpCn5DMcZntLyUY5c/rTDog28LhXLKOUZKoTxTCAdBVw==",
+            "dev": true
+        },
+        "mimic-fn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+            "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "dev": true
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "^1.0.0"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
+            "requires": {
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                    "dev": true
+                }
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            },
+            "dependencies": {
+                "callsites": {
+                    "version": "3.1.0",
+                    "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/callsites/-/callsites-3.1.0.tgz",
+                    "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
+                    "dev": true
+                }
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "progress": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+            "dev": true
+        },
+        "punycode": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+            "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+            "dev": true
+        },
+        "regexpp": {
+            "version": "2.0.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/regexpp/-/regexpp-2.0.1.tgz",
+            "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true,
+            "optional": true
+        },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
+            "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "align-text": "^0.1.1"
+            }
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "dev": true,
+            "requires": {
+                "is-promise": "^2.1.0"
+            }
+        },
+        "rxjs": {
+            "version": "6.5.2",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/rxjs/-/rxjs-6.5.2.tgz",
+            "integrity": "sha1-LjXOgVzUbYTQKiCftOWSHgUdvsc=",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.0"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+            "dev": true
+        },
+        "seedrandom": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
+            "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=",
+            "dev": true
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
         "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true,
-          "optional": true
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+            "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+            "dev": true,
+            "requires": {
+                "source-map": "^0.6.0"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                }
+            }
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+            "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^2.0.0"
+            }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
+        "tslib": {
+            "version": "1.9.3",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY=",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2"
+            }
+        },
+        "uglify-js": {
+            "version": "2.8.29",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "dev": true,
+            "optional": true
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "which": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "will-call": {
+            "version": "1.0.1",
+            "resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/will-call/-/will-call-1.0.1.tgz",
+            "integrity": "sha1-mzdWHqcVaquiGyj99jW4D+eL8WY=",
+            "dev": true
+        },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+            "dev": true,
+            "optional": true
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+            }
         }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "vise": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vise/-/vise-3.0.0.tgz",
-      "integrity": "sha512-kBFZLmiL1Vm3rHXphkhvvAcsjgeQXRrOFCbJb0I50YZZP4HGRNH+xGzK3matIMcpbsfr3I02u9odj4oCD0TWgA==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.0.2"
-      }
-    },
-    "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "dev": true,
-      "requires": {
-        "isexe": "2.0.0"
-      }
-    },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
-      "optional": true
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "wreck": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.0.2.tgz",
-      "integrity": "sha512-QCm3omWNJUseqrSzwX2QZi1rBbmCfbFHJAXputLLyZ37VSiFnSYQB0ms/mPnSvrlIu7GVm89Y/gBNhSY26uVIQ==",
-      "dev": true,
-      "requires": {
-        "boom": "7.1.1",
-        "hoek": "5.0.2"
-      }
-    },
-    "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
-        "window-size": "0.1.0"
-      }
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "description": "Apply policies to Hapi routes",
     "main": "lib/index",
     "scripts": {
-        "test": "lab -a code -t 100 -L"
+        "test": "lab -a @hapi/code -t 98 -L",
+        "coverage": "lab -a @hapi/code -t 98 -L -r html -o coverage.html"
     },
     "engines": {
         "node": ">=8.9.0"
@@ -24,15 +25,14 @@
     },
     "homepage": "https://github.com/mark-bradshaw/mrhorse",
     "dependencies": {
-        "boom": "7.x.x",
-        "hoek": "5.x.x",
-        "items": "2.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "6.x.x",
         "lodash": "4.x.x"
     },
     "devDependencies": {
-        "code": "5.x.x",
-        "hapi": "^17.2.0",
-        "lab": "15.x.x",
-        "wreck": "14.x.x"
+        "@hapi/code": "5.x.x",
+        "@hapi/hapi": "^18.3.1",
+        "@hapi/lab": "18.x.x",
+        "@hapi/wreck": "15.x.x"
     }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,10 @@
 /* eslint-disable */
 
 const MrHorse = require('..');
-const Code = require('code');
+const Code = require('@hapi/code');
 const fs = require('fs');
-const Hapi = require('hapi');
-const Lab = require('lab');
+const Hapi = require('@hapi/hapi');
+const Lab = require('@hapi/lab');
 const lab = exports.lab = Lab.script();
 const util = require('util');
 

--- a/test/policies/customError.js
+++ b/test/policies/customError.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Boom = require('boom');
+const Boom = require('@hapi/boom');
 
 const customFail = function () {
 


### PR DESCRIPTION
Hapi.js uses scoped packages for all its core modules:

- https://www.npmjs.com/package/@hapi/hapi
- https://www.npmjs.com/package/@hapi/hapi
- `...`

This PR:

- upgrades all dependencies to latest scoped versions. 
- fixes linter issue around using `arguments` vs `prefer-rest-params`
- dropped code coverage threshold to `98%`. It doesn't appear this PR contributed to code coverage drop.
- addd Node 10, 12 to travis matrix
- I believe this PR is considered breaking change
- removed `items` dependency since it appeared not to be used